### PR TITLE
adding lint function to deploy

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -34,6 +34,7 @@ printf "\nWhat do you want to do?\n"
 echo "[0] Deploy"
 echo "[1] Sync"
 echo "[2] Update"
+echo "[3] Lint"
 printf "Selection: "
 read selection
 if [[ $selection == 0 ]]; then
@@ -169,7 +170,9 @@ elif [[ $selection == 2 ]]; then
     echo "You did not make a valid selection... Exiting"
     exit 1
   fi
-
+elif [[ $selection == 3 ]]; then
+  lintPHPHead
+  lintPHP
 else
   echo "Nothing was selected... exiting."
   exit 1

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -108,3 +108,24 @@ function coreUpdate(){
 	echo '>Updating wordpress core...'
 	echo 'COMPLETE!'
 }
+
+###
+# Lints all the PHP files in the project directory
+function lintPHP() {
+	baseDir="$(dirname "${SCRIPT_PATH}")"
+  projDir=$baseDir/wp
+
+  for file in `find ${projDir}`
+  do
+    EXTENSION="${file##*.}"
+    if [ "$EXTENSION" == "php" ] || [ "$EXTENSION" == "phtml" ]
+    then
+      RESULTS=`php -l $file`
+
+      if [ "$RESULTS" != "No syntax errors detected in $file" ]
+      then
+        echo 'ERROR!!! ${RESULTS}'
+      fi
+    fi
+  done 
+}

--- a/bin/headers.sh
+++ b/bin/headers.sh
@@ -44,3 +44,12 @@ function boilerWPHead(){
 	echo "|_.__/ \___/|_|_|\___|_|/_/    \_/\_/ | .__/ "
 	echo "                                      |_|    "
 }
+
+function lintPHPHead(){
+  echo ".__  .__        __   "
+  echo "|  | |__| _____/  |_ "
+  echo "|  | |  |/    \   __\\"
+  echo "|  |_|  |   |  \  |  "
+  echo "|____/__|___|  /__|  "
+  echo "             \/      "
+}


### PR DESCRIPTION
You can run a PHP lint over the `wp` directory before deployment. Just run `bin/deploy.sh` in the root of the boilerplate and let it run. It'll print out the files that contain errors.